### PR TITLE
Feature/graphics trait api (DO NOT MERGE)

### DIFF
--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -392,6 +392,7 @@ impl<T: SubsystemManager + Default> Glulx<T> {
     }
     /// TODO
     pub fn op_quit(&mut self) {
+        self.io.quit();
         unimplemented!()
     }
     /// TODO
@@ -780,6 +781,7 @@ impl<T: SubsystemManager + Default> Glulx<T> {
         let start = self.memory.start_func();
         self.op_call(start, 0x0, Save::Null);
         loop {
+            self.io.tick();
             let opcode = self.opcode_number();
             self.eval(opcode);
         }

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,0 +1,86 @@
+pub trait SubsystemManager {
+    /// sets the active subsystem to the given mode and rock.
+    fn set_io_subsystem(&mut self, mode: u32, rock: u32);
+
+    /// Returns the currently used mode and rock.
+    fn get_io_subsystem(&self) -> (u32, u32);
+
+    /// Returns a value indicating whether the specified mode
+    /// is supported by the SubsytemManager.
+    ///
+    /// The checked codes are as follows:
+    ///
+    /// * `0x0`: `Null` `Subsystem`
+    /// * `0x1`: `Filter` `Subsystem`
+    /// * `0x2`: Glk `Subsystem`
+    /// * `0x3`: FyreVM `Subsystem`
+    fn gestalt_io_subsystem(&self, mode: u16) -> u32;
+}
+
+
+pub trait Subsystem {
+}
+
+
+#[derive(Default)]
+pub struct Filter {
+    pub rock: u32,
+}
+
+
+impl Filter {
+    pub fn new(rock: u32) -> Filter {
+        Filter{ rock: rock }
+    }
+}
+
+
+impl Subsystem for Filter {
+}
+
+
+#[derive(Default)]
+pub struct Null;
+
+
+impl Subsystem for Null {
+}
+
+
+pub struct DefaultManager {
+    mode: u32,
+    rock: u32,
+    subsystem: Box<Subsystem>,
+}
+
+
+impl Default for DefaultManager {
+    fn default() -> DefaultManager {
+        DefaultManager{
+            mode: 0x0,
+            rock: 0x0,
+            subsystem: Box::new(Null::default()),
+        }
+    }
+}
+
+
+impl SubsystemManager for DefaultManager {
+    fn set_io_subsystem(&mut self, mode: u32, rock: u32) {
+        self.subsystem = match mode {
+            0x0 => Box::new(Null::default()),
+            0x1 => Box::new(Filter::new(rock)),
+            _ => panic!("unsupported io subsystem requested"),
+        };
+        self.mode = mode;
+        self.rock = rock;
+    }
+
+    fn get_io_subsystem(&self) -> (u32, u32) {
+        (self.mode, self.rock)
+    }
+
+    fn gestalt_io_subsystem(&self, mode: u16) -> u32 {
+        if let 0x0...0x1 = mode { 0x1 } else { 0x0 }
+    }
+}

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,4 +1,4 @@
-pub trait SubsystemManager {
+pub trait SubsystemManager: Subsystem {
     /// sets the active subsystem to the given mode and rock.
     fn set_io_subsystem(&mut self, mode: u32, rock: u32);
 
@@ -19,6 +19,8 @@ pub trait SubsystemManager {
 
 
 pub trait Subsystem {
+    fn tick(&mut self);
+    fn quit(&mut self);
 }
 
 
@@ -36,6 +38,8 @@ impl Filter {
 
 
 impl Subsystem for Filter {
+    fn tick(&mut self){ /* NOP */ }
+    fn quit(&mut self){ /* NOP */ }
 }
 
 
@@ -44,6 +48,8 @@ pub struct Null;
 
 
 impl Subsystem for Null {
+    fn tick(&mut self){ /* NOP */ }
+    fn quit(&mut self){ /* NOP */ }
 }
 
 
@@ -83,4 +89,10 @@ impl SubsystemManager for DefaultManager {
     fn gestalt_io_subsystem(&self, mode: u16) -> u32 {
         if let 0x0...0x1 = mode { 0x1 } else { 0x0 }
     }
+
+}
+
+impl Subsystem for DefaultManager {
+    fn tick(&mut self){ /* NOP */ }
+    fn quit(&mut self){ /* NOP */ }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ extern crate byteorder;
 mod interpreter;
 mod memory;
 mod stack;
+pub mod io;
 
 pub use interpreter::Glulx;
 


### PR DESCRIPTION
This is a possible implementation for how io operations will be handled -- similar to how io operations are handled for my chip-8 emulator -- through a trait.

There are a few things I need to consider before either merging or rejecting these changes:

* Do we want to use a trait to control the API?
   * Implementors using this vm would need to implement the trait functions, which I'm not entirely sure that's proper. The other options would be linking to c-wrapper libraries for glk and (maybe someday -- haha) fyreVM.
* Should SubsystemManager implement Subsystem?
  * This allows for shortcutting unnecessary functions. Because the subsystem is switchable while the glulxVM is running, dynamic dispatch is unavoidable (I think). By making SubsystemManager a Subsystem, SubsystemManager can implement a NOP for functions which it doesn't support, which the compiler will then remove. Important examples would be any machine which doesn't implement tick or quit. tick is called every loop, and allowing that to be optimized out would probably be a decent performance gain.
* Should DefaultManager be part of io?
   * The DefaultManager implements a SubsystemManager which only supports the Filter and Null Subsystems. However, this isn't used by the library, but is currently publicly exported. I need to figure out whether this should be moved to a simple main.rs, or removed entirely from the baseline.
* How the hell does filter work?
  * Filter needs to be able to call machine code, which really convolutes this entire thing. How is Filter supposed to be able to get access to the machine to do so?

- [ ] determine whether to use trait system.
- [ ] determine whether SubsytemManager should implement Subsystem.
- [ ] determine whether to remove DefaultManager from the io module.
- [ ] determine whether the who Filter concept is even workable with this setup.